### PR TITLE
Added header and item decoration accessors

### DIFF
--- a/core/src/main/java/it/carlom/stikkyheader/core/StikkyHeader.java
+++ b/core/src/main/java/it/carlom/stikkyheader/core/StikkyHeader.java
@@ -157,4 +157,8 @@ public abstract class StikkyHeader {
         return mContext;
     }
 
+    public View getHeader() {
+        return mHeader;
+    }
+
 }

--- a/core/src/main/java/it/carlom/stikkyheader/core/StikkyHeaderRecyclerView.java
+++ b/core/src/main/java/it/carlom/stikkyheader/core/StikkyHeaderRecyclerView.java
@@ -14,6 +14,7 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
     private RecyclerView mRecyclerView;
     private int mScrolledY;
     private OnScrollListenerStikky mOnScrollerListenerStikky;
+    private RecyclerView.ItemDecoration mItemDecoration;
 
     StikkyHeaderRecyclerView(final Context context, final RecyclerView recyclerView, final View header, final int minHeightHeader, final HeaderAnimator headerAnimator) {
         super(context, recyclerView, header, minHeightHeader, headerAnimator);
@@ -34,6 +35,10 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
         setupOnScrollListener();
     }
 
+    public RecyclerView.ItemDecoration getItemDecoration() {
+        return mItemDecoration;
+    }
+
     private void setupItemDecorator() {
 
         final RecyclerView.LayoutManager layoutManager = mRecyclerView.getLayoutManager();
@@ -43,7 +48,7 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
 
             switch (orientation) {
                 case StaggeredGridLayoutManager.VERTICAL:
-                    mRecyclerView.addItemDecoration(new RecyclerView.ItemDecoration() {
+                    mItemDecoration = new RecyclerView.ItemDecoration() {
                         @Override
                         public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
                             super.getItemOffsets(outRect, view, parent, state);
@@ -54,7 +59,8 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
                                 outRect.top = mHeightHeader;
                             }
                         }
-                    });
+                    };
+                    mRecyclerView.addItemDecoration(mItemDecoration);
 
                     break;
 
@@ -69,7 +75,7 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
 
             switch (orientation) {
                 case LinearLayoutManager.VERTICAL:
-                    mRecyclerView.addItemDecoration(new RecyclerView.ItemDecoration() {
+                    mItemDecoration = new RecyclerView.ItemDecoration() {
                         @Override
                         public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
                             super.getItemOffsets(outRect, view, parent, state);
@@ -80,7 +86,8 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
                                 outRect.top = mHeightHeader;
                             }
                         }
-                    });
+                    };
+                    mRecyclerView.addItemDecoration(mItemDecoration);
 
                     break;
 
@@ -95,8 +102,7 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
 
             switch (orientation) {
                 case LinearLayoutManager.VERTICAL:
-
-                    mRecyclerView.addItemDecoration(new RecyclerView.ItemDecoration() {
+                    mItemDecoration = new RecyclerView.ItemDecoration() {
                         @Override
                         public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
                             super.getItemOffsets(outRect, view, parent, state);
@@ -105,7 +111,8 @@ public class StikkyHeaderRecyclerView extends StikkyHeader {
                                 outRect.top = mHeightHeader;
                             }
                         }
-                    });
+                    };
+                    mRecyclerView.addItemDecoration(mItemDecoration);
 
                     break;
 


### PR DESCRIPTION
I added accessors in case to remove & add again header on action expand & hide:
```
 MenuItemCompat.setOnActionExpandListener(searchMenuItem, object : MenuItemCompat.OnActionExpandListener {
            override fun onMenuItemActionExpand(item: MenuItem): Boolean {
                stickyHeader.getHeader().setVisibility(View.GONE)
                recyclerView.removeItemDecoration(stickyHeader.getItemDecoration())
                return true
            }

            override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                stickyHeader.getHeader().setVisibility(View.VISIBLE)
                recyclerView.addItemDecoration(stickyHeader.getItemDecoration())
                return true
            }

        }) 
```